### PR TITLE
Add scheduled ChatGPT script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,23 @@ Your Pages site will use the layout and styles from the Jekyll theme you have se
 ### Support or Contact
 
 Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+
+### Scheduled ChatGPT Usage
+
+A new script `scheduled_chatgpt.py` lets you run ChatGPT prompts automatically. The script uses the `openai` and `schedule` packages.
+
+Example usage to run daily at 9 AM:
+
+```bash
+python scheduled_chatgpt.py "Hello, world" --daily --time 09:00
+```
+
+Replace the prompt with your own text. Set `OPENAI_API_KEY` in your environment to authenticate with OpenAI.
+
+For a weekly run on Mondays at 8 AM:
+
+```bash
+python scheduled_chatgpt.py "Weekly report" --weekly monday --time 08:00
+```
+
+The script will keep running, checking the schedule every second. Use cron or a process manager to run it in the background.

--- a/scheduled_chatgpt.py
+++ b/scheduled_chatgpt.py
@@ -1,0 +1,66 @@
+import os
+import argparse
+import openai
+import schedule
+import time
+
+
+def run_prompt(prompt: str, model: str = "gpt-3.5-turbo") -> None:
+    """Send a prompt to the OpenAI API and print the response."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    answer = response.choices[0].message.content
+    print(answer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ChatGPT prompts on a schedule")
+    parser.add_argument("prompt", help="The prompt text to send to ChatGPT")
+    parser.add_argument("--time", default="09:00", help="Time of day to run (HH:MM)")
+    parser.add_argument(
+        "--daily", action="store_true", help="Run the prompt every day at the specified time"
+    )
+    parser.add_argument(
+        "--weekly",
+        metavar="DAY",
+        help="Run the prompt weekly on the given day (e.g. monday) at the specified time",
+    )
+    parser.add_argument(
+        "--once", action="store_true", help="Run the prompt a single time and exit"
+    )
+    parser.add_argument(
+        "--model", default="gpt-3.5-turbo", help="Model name for OpenAI completion"
+    )
+
+    args = parser.parse_args()
+
+    if args.once:
+        run_prompt(args.prompt, args.model)
+        return
+
+    if args.daily:
+        schedule.every().day.at(args.time).do(run_prompt, args.prompt, args.model)
+    elif args.weekly:
+        day = args.weekly.lower()
+        if not hasattr(schedule.every(), day):
+            raise ValueError(f"Invalid day of week: {args.weekly}")
+        getattr(schedule.every(), day).at(args.time).do(
+            run_prompt, args.prompt, args.model
+        )
+    else:
+        parser.error("Either --daily, --weekly DAY, or --once must be specified")
+
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scheduled_chatgpt.py` for running prompts automatically
- document how to use the scheduler in the README

## Testing
- `python -m py_compile scheduled_chatgpt.py`
